### PR TITLE
Use `===` over `==`

### DIFF
--- a/data-analytics.js
+++ b/data-analytics.js
@@ -3,7 +3,7 @@
  */
 (function(data_analytics) {
 	function clicked(e) {
-		var tag = e.target||e.srcElement;  (tag.nodeType==1)||(tag = tag.parentNode);
+		var tag = e.target||e.srcElement;  (tag.nodeType===1)||(tag = tag.parentNode);
 		var dav = data_analytics.values(tag);
 		var a, actiontags = {A:1, AREA:1, BUTTON:1}, i, imp;
 		for (a = tag; a && !(a.tagName in actiontags); a = a.parentNode); //a = ancestor action tag


### PR DESCRIPTION
Some comparisons are more equal than others. Use `===` instead of `==`... `nodeType` should always be an Integer, so this shouldn't be a problem to my knowledge.

But I mean, who knows if this breaks some old weird browser.
